### PR TITLE
Reactions and Post Reactions

### DIFF
--- a/rare/urls.py
+++ b/rare/urls.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.conf.urls import include
 from django.urls import path
 
-from rareapi.views import register_user,  login_user, CategoryView, CommentView, UserView
+from rareapi.views import register_user,  login_user, CategoryView, CommentView, UserView, ReactionView, PostReactionView
 
 from rest_framework import routers
 from rareapi.views.subscriptions import SubscriptionView
@@ -18,6 +18,8 @@ router.register(r'comments', CommentView, 'comment')
 router.register(r"posts", PostView, "post")
 router.register(r'tags', TagView, 'tag')
 router.register(r'users', UserView, 'user')
+router.register(r'reactions', ReactionView, 'reaction')
+router.register(r'postreactions', PostReactionView, 'postreaction')
 
 urlpatterns = [
     path('register', register_user),

--- a/rareapi/models/__init__.py
+++ b/rareapi/models/__init__.py
@@ -4,3 +4,5 @@ from .categories import Category
 from .post import Post
 from .tag import Tag
 from .comment import Comment
+from .reaction import Reaction
+from. post_reaction import PostReaction

--- a/rareapi/models/post_reaction.py
+++ b/rareapi/models/post_reaction.py
@@ -1,0 +1,6 @@
+from django.db import models
+
+class PostReaction(models.Model):
+    user = models.ForeignKey("theUser", on_delete=models.CASCADE)
+    post = models.ForeignKey("Post", on_delete=models.CASCADE, related_name="post_reactions")
+    reaction = models.ForeignKey("Reaction", on_delete=models.CASCADE)

--- a/rareapi/models/reaction.py
+++ b/rareapi/models/reaction.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+class Reaction(models.Model):
+    label = models.CharField(max_length=150)
+    image_url = models.TextField()

--- a/rareapi/views/__init__.py
+++ b/rareapi/views/__init__.py
@@ -5,4 +5,5 @@ from .tag import TagView
 from .commentView import CommentView
 from .categoryView import CategoryView
 from .userview import UserView
-
+from .reaction import ReactionView
+from .post_reaction import PostReactionView

--- a/rareapi/views/post.py
+++ b/rareapi/views/post.py
@@ -65,7 +65,7 @@ class PostView(ViewSet):
 class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
-        fields = 'id', 'title', 'publication_date', 'image_url', 'content', 'approved', 'category', 'post_reactions'
+        fields = 'id', 'user', 'title', 'publication_date', 'image_url', 'content', 'approved', 'category', 'post_reactions'
         depth = 2
 
 class CreatePostSerializer(serializers.ModelSerializer):

--- a/rareapi/views/post.py
+++ b/rareapi/views/post.py
@@ -65,7 +65,7 @@ class PostView(ViewSet):
 class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
-        fields = "__all__"
+        fields = 'id', 'title', 'publication_date', 'image_url', 'content', 'approved', 'category', 'post_reactions'
         depth = 2
 
 class CreatePostSerializer(serializers.ModelSerializer):

--- a/rareapi/views/post_reaction.py
+++ b/rareapi/views/post_reaction.py
@@ -1,0 +1,102 @@
+from django.forms import ValidationError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from rareapi.models import Reaction, Post, PostReaction
+from rareapi.models.user import theUser
+
+
+class PostReactionView(ViewSet):
+    """Rare post_reactions"""
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single post_reaction
+
+        Returns:
+            Response -- JSON serialized post_reaction
+        """
+        try:
+            post_reaction = PostReaction.objects.get(pk=pk)
+            serializer = PostReactionSerializer(post_reaction)
+            return Response(serializer.data)
+        except PostReaction.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND) 
+
+
+    def list(self, request):
+        """Handle GET requests to get all post_reactions
+
+        Returns:
+            Response -- JSON serialized list of post_reactions
+        """
+        post_reactions = PostReaction.objects.all()
+        serializer = PostReactionSerializer(post_reactions, many=True)
+        return Response(serializer.data)
+
+
+    def create(self, request):
+        """Handle POST request to create new post_reaction
+
+        Returns:
+            Response -- JSON serialized post_reaction
+        """
+        
+        post=Post.objects.get(pk=request.data['post_id'])
+        reaction=Reaction.objects.get(pk=request.data['reaction_id'])
+        user = theUser.objects.get(user = request.auth.user)
+        
+        post_reaction = PostReaction.objects.create(
+            user = user,
+            post = post,
+            reaction = reaction
+        )
+        try:
+            post_reaction.save()
+            serializer = PostReactionSerializer(post_reaction)
+            return Response (serializer.data, status=status.HTTP_201_CREATED)
+        except ValidationError as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
+    def update(self, request, pk=None):
+        """Handle PUT request for a single reaction
+
+        Returns:
+            No content, 204 status.
+        """
+        try:
+            post = Post.objects.get(pk=request.data['post_id'])
+            reaction = Reaction.objects.get(pk=request.data['reaction_id'])
+            
+            post_reaction = PostReaction.objects.get(pk=pk)
+            post_reaction.post = post
+            post_reaction.reaction = reaction
+            post_reaction.save()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+        except PostReaction.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+        except ValidationError as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
+    def destroy(self, request, pk=None):
+        """Handle DELETE request for a single post_reaction
+
+        Returns:
+            No content, 204 status.
+        """
+        try:
+            post_reaction = PostReaction.objects.get(pk=pk)
+            post_reaction.delete()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+        except PostReaction.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class PostReactionSerializer(serializers.ModelSerializer):
+    """JSON serializer for post_reaction
+    """
+    class Meta:
+        model = PostReaction
+        fields = ('id', 'user', 'post', 'reaction')
+        depth = 1

--- a/rareapi/views/reaction.py
+++ b/rareapi/views/reaction.py
@@ -1,0 +1,91 @@
+from django.forms import ValidationError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from rareapi.models import Reaction
+
+
+class ReactionView(ViewSet):
+    """Rare reactions"""
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single reaction
+
+        Returns:
+            Response -- JSON serialized reaction
+        """
+        try:
+            reaction = Reaction.objects.get(pk=pk)
+            serializer = ReactionSerializer(reaction)
+            return Response(serializer.data)
+        except Reaction.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND) 
+
+
+    def list(self, request):
+        """Handle GET requests to get all reactions
+
+        Returns:
+            Response -- JSON serialized list of reactions
+        """
+        reactions = Reaction.objects.all()
+        serializer = ReactionSerializer(reactions, many=True)
+        return Response(serializer.data)
+    
+    
+    def create(self, request):
+        """Handle POST request to create new reaction
+
+        Returns:
+            Response -- JSON serialized reaction
+        """
+        reaction = Reaction.objects.create(
+            label=request.data['label'],
+            image_url=request.data['image_url']
+        )
+        try:
+            reaction.save()
+            serializer = ReactionSerializer(reaction)
+            return Response (serializer.data, status=status.HTTP_201_CREATED)
+        except ValidationError as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+    
+    
+    def destroy(self, request, pk=None):
+        """Handle DELETE request for a single reaction
+
+        Returns:
+            No content, 204 status.
+        """
+        try:
+            reaction = Reaction.objects.get(pk=pk)
+            reaction.delete()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+        except Reaction.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
+    def update(self, request, pk=None):
+        """Handle PUT request for a single reaction
+
+        Returns:
+            No content, 204 status.
+        """
+        try:
+            reaction = Reaction.objects.get(pk=pk)
+            reaction.label = request.data['label']
+            reaction.image_url = request.data['image_url']
+            reaction.save()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+        except Reaction.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+        except ValidationError as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ReactionSerializer(serializers.ModelSerializer):
+    """JSON serializer for game types
+    """
+    class Meta:
+        model = Reaction
+        fields = ('id', 'label', 'image_url')


### PR DESCRIPTION
Added models and complete view sets for Reaction and PostReaction, and updated URLs.

*Altered PostViewSerializer to be explicit and added post_reactions field

To test in Postman (after migrating tables and loading data from fixtures):
GET requests for all reactions and all postreactions
GET single request for single reaction/1 and single postreaction/1
POST single reaction and postreaction
UPDATE single reaction and postreaction
DELETE single reaction and post reaction

* GET either a single or a list of posts. Each post object should include a field for "post_reactions". Provided there is at least one postreaction associated with a post it should appear within that list.

Fixes #38 
Fixes #39 
Fixes #43 
