### PR TITLE
Admin Actions

### DIFF
--- a/rareapi/views/userview.py
+++ b/rareapi/views/userview.py
@@ -49,6 +49,29 @@ class UserView(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
 
+    @action(methods=['put'], detail=True)
+    def makeadmin(self, request, pk):
+        try:
+            user = User.objects.get(pk=pk)
+            user.is_staff = 1
+            user.save()
+            return Response ({'message: User is now an admin'}, status=status.HTTP_204_NO_CONTENT)
+        except User.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
+    @action(methods=['put'], detail=True)
+    def removeadmin(self, request, pk):
+        try:
+            user = User.objects.get(pk=pk)
+            user.is_staff = 0
+            user.save()
+            return Response ({'message: User has been removed as an admin'}, status=status.HTTP_204_NO_CONTENT)
+        except User.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
+
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
Added custom actions to add and remove admin permissions for users by modifying the 'is_staff' property of the associated django user.

To Test in Postman:
- Turn a user into an Admin by making a PUT request to users/#/makeadmin (where # is the user_id of the affected user)
- Remove a user as an Admin by making a PUT request to users/#/removeadmin (where # is the user_id of the affected user)
- In both cases a confirmation message should be returned in Postman and you can confirm changes in the databse by checking the auth_user table in SQLITE Explorer

Supports #30 
Supports #37 
Supports #47 